### PR TITLE
fix: limit annotate length

### DIFF
--- a/capirca/lib/nokia.py
+++ b/capirca/lib/nokia.py
@@ -785,6 +785,9 @@ class Nokia(aclgenerator.ACLGenerator):
           cli_path = "filter match-list %s %s prefix %s" % ("ipv6-prefix-list" if ip.version == 6 else "ip-prefix-list", name[:32], write_ip)
           config.Append('/configure %s' % cli_path)
           if ip.text:
+            # Truncate annotate to comply with SROS 2048 char limitation
+            if len(ip.text) > 2040:
+              ip.text = ip.text[:2040] + '...'
             config.Append('annotate "%s" cli-path %s' % (ip.text.replace("\n", "\\n"), cli_path))
 
       # Write out excludes


### PR DESCRIPTION
Hi,
We have hit the SROS annotate limit due to multiple IPs with annotations being combined in a /25 subnet.
The result is an annotate statement in the ip-prefix-list that exceeds 2048 characters.
This PR is simply to truncate the comment.
Thanks.